### PR TITLE
ヘルスチェック用の API エンドポイントを実装

### DIFF
--- a/backend/app/controllers/api/health_check_controller.rb
+++ b/backend/app/controllers/api/health_check_controller.rb
@@ -1,0 +1,5 @@
+class Api::HealthCheckController < ApplicationController
+  def index
+    render json: { status: 'ok' }, status: :ok
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  namespace :api do
+    get 'health_check', to: 'health_check#index'
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/backend/test/controllers/api/health_check_controller_test.rb
+++ b/backend/test/controllers/api/health_check_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Api::HealthCheckControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get api_health_check_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
ヘルスチェック用の API エンドポイントを実装しました。

- `Api::HealthCheckController#index` を追加し、`GET /api/health_check` で `{ "status": "ok" }` を返すようにしました。
- `config/routes.rb` にルーティングを追加。

## 確認方法
```bash
curl -i http://localhost:3001/api/health_check
# ステータス 200 と {"status":"ok"} が返ること
```

## 確認結果
ステータス：200 OK
レスポンスボディ：{"status":"ok"}